### PR TITLE
fix: splat options to match definition in ActiveModel

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -61,8 +61,8 @@ if defined?(ActiveRecord::Base)
             end
 
             if ::ActiveRecord::VERSION::STRING >= "4.1"
-              define_method("#{attr}_changed?") do |options = {}|
-                attribute_changed?(attr, options)
+              define_method("#{attr}_changed?") do |*options|
+                attribute_changed?(attr, *options)
               end
             else
               define_method("#{attr}_changed?") do


### PR DESCRIPTION
This is needed to make the monolith Ruby 3 compliant. Patching the method call to match what is in ActiveModel here: https://github.com/rails/rails/blob/v6.1.7.1/activemodel/lib/active_model/attribute_methods.rb#L412