### PR TITLE
Add Quick Change workflow

### DIFF
--- a/.github/workflows/quick_change.yml
+++ b/.github/workflows/quick_change.yml
@@ -1,0 +1,40 @@
+---
+name: Quick Change
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  call-reusable-quick-change:
+    name: Run
+    if: |
+      github.event_name == 'pull_request' ||
+      (
+        (
+          (github.event_name == 'issue_comment' && github.event.issue.pull_request) ||
+          github.event_name == 'pull_request_review_comment'
+        ) &&
+        contains(github.event.comment.body, '@ws-quick-change') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR' ||
+          github.event.comment.author_association == 'CONTRIBUTOR'
+        )
+      )
+
+    uses: wealthsimple/quick-change/.github/workflows/quick_change.yml@main
+
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds the Quick Change GitHub Actions workflow (`.github/workflows/quick_change.yml`) to enable AI-assisted code changes directly from PRs, Jira tickets, and Slack.

## What is Quick Change?

Quick Change (`@ws-quick-change`) is an AI-powered coding agent that can automatically generate code changes for this repository. It runs as a GitHub Actions workflow triggered on PR events and responds to `@ws-quick-change` mentions in PR comments from org members.

## Benefits

- **Faster iteration** — Get working code changes proposed automatically instead of waiting for manual implementation
- **Lower barrier to contribution** — Engineers unfamiliar with a repo can describe what they need in plain language and get a PR with the right changes
- **Multiple entry points** — Quick Change can be triggered from:
  - **Jira** — Create a ticket describing the change and Quick Change will open a PR automatically
  - **Slack** — Request changes directly from Slack and have them turned into PRs
  - **GitHub PRs** — Mention `@ws-quick-change` in any PR comment to request modifications or follow-ups
- **Review-friendly** — All changes go through the normal PR review process, so code quality and approval gates are preserved

## What this PR changes

Adds a single workflow file (`.github/workflows/quick_change.yml`) that calls the reusable workflow from `wealthsimple/quick-change`. No other files are modified.
